### PR TITLE
Fix add note bug

### DIFF
--- a/iosApp/iosApp/note_list/NoteListScreen.swift
+++ b/iosApp/iosApp/note_list/NoteListScreen.swift
@@ -31,7 +31,7 @@ struct NoteListScreen: View {
                 }, destinationProvider: {
                     NoteDetailScreen(
                         noteDataSource: noteDataSource,
-                        noteId: selectedNoteId
+                        noteId: nil
                     )
                 }, isSearchActive: viewModel.isSearchActive, searchText: $viewModel.searchText)
                 .frame(maxWidth: .infinity, minHeight: 40)


### PR DESCRIPTION
When you `previously select a note > go back > try to add a new note`, it will load last selected note. pass `nil` instead to fix the issue.