### PR TITLE
fix of crash when Note class could not be serialized

### DIFF
--- a/androidApp/src/main/java/com/plcoding/noteappkmm/android/note_list/NoteListViewModel.kt
+++ b/androidApp/src/main/java/com/plcoding/noteappkmm/android/note_list/NoteListViewModel.kt
@@ -1,31 +1,25 @@
 package com.plcoding.noteappkmm.android.note_list
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.plcoding.noteappkmm.domain.note.Note
 import com.plcoding.noteappkmm.domain.note.NoteDataSource
 import com.plcoding.noteappkmm.domain.note.SearchNotes
-import com.plcoding.noteappkmm.domain.time.DateTimeUtil
-import com.plcoding.noteappkmm.presentation.RedOrangeHex
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class NoteListViewModel @Inject constructor(
-    private val noteDataSource: NoteDataSource,
-    private val savedStateHandle: SavedStateHandle
+    private val noteDataSource: NoteDataSource
 ): ViewModel() {
 
     private val searchNotes = SearchNotes()
 
-    private val notes = savedStateHandle.getStateFlow("notes", emptyList<Note>())
-    private val searchText = savedStateHandle.getStateFlow("searchText", "")
-    private val isSearchActive = savedStateHandle.getStateFlow("isSearchActive", false)
+    private val notes = MutableStateFlow(emptyList<Note>())
+    private val searchText = MutableStateFlow("")
+    private val isSearchActive = MutableStateFlow(false)
 
     val state = combine(notes, searchText, isSearchActive) { notes, searchText, isSearchActive ->
         NoteListState(
@@ -37,18 +31,18 @@ class NoteListViewModel @Inject constructor(
 
     fun loadNotes() {
         viewModelScope.launch {
-            savedStateHandle["notes"] = noteDataSource.getAllNotes()
+            notes.value = noteDataSource.getAllNotes()
         }
     }
 
     fun onSearchTextChange(text: String) {
-        savedStateHandle["searchText"] = text
+        searchText.value = text
     }
 
     fun onToggleSearch() {
-        savedStateHandle["isSearchActive"] = !isSearchActive.value
+        isSearchActive.update { !it }
         if(!isSearchActive.value) {
-            savedStateHandle["searchText"] = ""
+            searchText.value = ""
         }
     }
 


### PR DESCRIPTION
crash was mentioned [here](https://github.com/philipplackner/NoteAppKMM/issues/3)

boilerplate but could not just add Parcelable annotation to Note class because it is contained in pure Kotlin module :( 

UPDATE: 
sorry, I changed approach, I think SavedStateHandler is not needed on list because all notes are persisted in DB anyway.

On details it's useful because it can save user input which was not persisted in db yet. 

